### PR TITLE
TD-3922: Add ROLLOUT_BATCH_SIZE and it's logic

### DIFF
--- a/eksrollup/cli.py
+++ b/eksrollup/cli.py
@@ -146,120 +146,119 @@ def scale_up_asg(cluster_name, asg, count):
 def update_asgs(asgs, cluster_name):
     run_mode = app_config['RUN_MODE']
     use_asg_termination_policy = app_config['ASG_USE_TERMINATION_POLICY']
+    batch_size = app_config.get('ROLLOUT_BATCH_SIZE', None)  # e.g. 3 or None
 
+    # pick your planner
     if run_mode == 4:
-        asg_outdated_instance_dict = plan_asgs_older_nodes(asgs)
-
+        asg_outdated = plan_asgs_older_nodes(asgs)
     else:
-        asg_outdated_instance_dict = plan_asgs(asgs)
-
-    asg_state_dict = {}
-
-    if run_mode == 2:
-        # Scale up all the ASGs with outdated nodes (by the number of outdated nodes)
-        for asg_name, asg_tuple in asg_outdated_instance_dict.items():
-            outdated_instances, asg = asg_tuple
-            outdated_instance_count = len(outdated_instances)
-            logger.info(
-                f'Setting the scale of ASG {asg_name} based on {outdated_instance_count} outdated instances.')
-            asg_state_dict[asg_name] = scale_up_asg(cluster_name, asg, outdated_instance_count)
+        asg_outdated = plan_asgs(asgs)
 
     k8s_nodes, k8s_excluded_nodes = get_k8s_nodes()
-    if (run_mode == 2) or (run_mode == 3):
-        for asg_name, asg_tuple in asg_outdated_instance_dict.items():
-            outdated_instances, asg = asg_tuple
-            for outdated in outdated_instances:
-                node_name = ""
-                try:
-                    # get the k8s node name instead of instance id
-                    node_name = get_node_by_instance_id(k8s_nodes, outdated['InstanceId'])
-                    if not app_config["TAINT_NODES"]:
-                        cordon_node(node_name)
-                    else:
-                        taint_node(node_name)
-                except Exception as exception:
-                    logger.error(f"Encountered an error when adding taint/cordoning node {node_name}")
-                    logger.error(exception)
-                    exit(1)
+    asg_state = {}
 
-    # Drain, Delete and Terminate the outdated nodes and return the ASGs back to their original state
-    for asg_name, asg_tuple in asg_outdated_instance_dict.items():
-        outdated_instances, asg = asg_tuple
-        outdated_instance_count = len(outdated_instances)
+    for asg_name, (outdated_instances, asg_obj) in asg_outdated.items():
+        total = len(outdated_instances)
+        if total == 0:
+            continue
 
-        if (run_mode == 1) or (run_mode == 3) or (run_mode == 4):
-            logger.info(
-                f'Setting the scale of ASG {asg_name} based on {outdated_instance_count} outdated instances.')
-            asg_state_dict[asg_name] = scale_up_asg(cluster_name, asg, outdated_instance_count)
+        # how many at a time?
+        bs = batch_size or total
 
-        if (run_mode == 1) or (run_mode == 4):
-            for outdated in outdated_instances:
-                node_name = ""
-                try:
-                    # get the k8s node name instead of instance id
-                    node_name = get_node_by_instance_id(k8s_nodes, outdated['InstanceId'])
-                    if not app_config["TAINT_NODES"]:
-                        cordon_node(node_name)
-                    else:
-                        taint_node(node_name)
-                except Exception as exception:
-                    try:
-                        node_name = get_node_by_instance_id(k8s_excluded_nodes, outdated['InstanceId'])
-                        logger.info(f"Node {node_name} was excluded")
-                        continue
-                    except Exception as exception:
-                        logger.error(f"Encountered an error when adding taint/cordoning node {node_name}")
-                        logger.error(exception)
-                        exit(1)
+        # 1) SCALE UP ONCE by batch-size for head-room
+        logger.info(f'Scaling ASG {asg_name} up by {bs} for batch head-room')
+        new_desired, orig_desired, orig_max = scale_up_asg(cluster_name, asg_obj, bs)
+        asg_state[asg_name] = (new_desired, orig_desired, orig_max)
 
-        if len(outdated_instances) != 0:
-            # if ASG termination is ignored then suspend 'Launch' and 'ReplaceUnhealthy'
-            # for this ASG to avoid instances being spawned during terminate/detach phase
-            if not use_asg_termination_policy:
-                modify_aws_autoscaling(asg_name, "suspend")
+        # save original state tags if your scale_up_asg doesn’t already do it
+        save_asg_tags(asg_name, app_config["ASG_DESIRED_STATE_TAG"], new_desired)
+        save_asg_tags(asg_name, app_config["ASG_ORIG_CAPACITY_TAG"], orig_desired)
+        save_asg_tags(asg_name, app_config["ASG_ORIG_MAX_CAPACITY_TAG"], orig_max)
 
-        # start draining and terminating
-        desired_asg_capacity = asg_state_dict[asg_name][0]
-        for outdated in outdated_instances:
-            # catch any failures so we can resume aws autoscaling
-            try:
-                # get the k8s node name instead of instance id
-                node_name = get_node_by_instance_id(k8s_nodes, outdated['InstanceId'])
-                desired_asg_capacity -= 1
-                drain_node(node_name)
-                delete_node(node_name)
-                save_asg_tags(asg_name, app_config["ASG_DESIRED_STATE_TAG"], desired_asg_capacity)
-                # terminate/detach outdated instances only if ASG termination policy is ignored
-                if not use_asg_termination_policy:
-                    terminate_instance_in_asg(outdated['InstanceId'])
-                    if not instance_terminated(outdated['InstanceId']):
-                        raise Exception('Instance is failing to terminate. Cancelling out.')
-
-                    between_nodes_wait = app_config['BETWEEN_NODES_WAIT']
-                    if between_nodes_wait != 0:
-                        logger.info(f'Waiting for {between_nodes_wait} seconds before continuing...')
-                        time.sleep(between_nodes_wait)
-            except Exception as drain_exception:
-                try:
-                    node_name = get_node_by_instance_id(k8s_excluded_nodes, outdated['InstanceId'])
-                    logger.info(f"Node {node_name} was excluded")
-                    continue
-                except:
-                    raise RollingUpdateException("Rolling update on ASG failed", asg_name)
-
-        # scaling cluster back down
-        logger.info("Scaling asg back down to original state")
-        asg_desired_capacity, asg_orig_desired_capacity, asg_orig_max_capacity = asg_state_dict[asg_name]
-        scale_asg(asg_name, asg_desired_capacity, asg_orig_desired_capacity, asg_orig_max_capacity)
-        # resume aws autoscaling only if ASG termination policy is ignored
+        # suspend AWS’s own launch/replace if you’re doing manual termination
         if not use_asg_termination_policy:
-            modify_aws_autoscaling(asg_name, "resume")
-        # remove aws tag
+            modify_aws_autoscaling(asg_name, 'suspend')
+
+        # 2) process in batches
+        remaining = list(outdated_instances)
+        while remaining:
+            batch = remaining[:bs]
+            remaining = remaining[bs:]
+
+            # a) cordon/taint for RUN_MODE 2 & 3
+            if run_mode in (2, 3):
+                for inst in batch:
+                    node = get_node_by_instance_id(k8s_nodes, inst['InstanceId'])
+                    if app_config.get("TAINT_NODES"):
+                        taint_node(node)
+                    else:
+                        cordon_node(node)
+
+            # b) cordon/taint for RUN_MODE 1 & 4 (with excluded‐node fallback)
+            if run_mode in (1, 4):
+                for inst in batch:
+                    try:
+                        node = get_node_by_instance_id(k8s_nodes, inst['InstanceId'])
+                    except Exception:
+                        # maybe it was already excluded?
+                        node = get_node_by_instance_id(k8s_excluded_nodes, inst['InstanceId'])
+                        logger.info(f"Node {node} was excluded")
+                        continue
+
+                    if app_config.get("TAINT_NODES"):
+                        taint_node(node)
+                    else:
+                        cordon_node(node)
+
+            # c) drain & terminate for RUN_MODE 1,3,4
+            if run_mode in (1, 3, 4):
+                desired_cap, od, om = asg_state[asg_name]
+                for inst in batch:
+                    try:
+                        node = get_node_by_instance_id(k8s_nodes, inst['InstanceId'])
+                    except Exception:
+                        node = get_node_by_instance_id(k8s_excluded_nodes, inst['InstanceId'])
+                        logger.info(f"Node {node} was excluded")
+                        continue
+
+                    drain_node(node)
+                    delete_node(node)
+
+                    # decrement and re-save the DESIRED_STATE tag
+                    # desired_cap -= 1
+                    save_asg_tags(asg_name, app_config["ASG_DESIRED_STATE_TAG"], desired_cap)
+
+                    if not use_asg_termination_policy:
+                        terminate_instance_in_asg(inst['InstanceId'])
+                        if not instance_terminated(inst['InstanceId']):
+                            raise Exception("Instance failed to terminate")
+                        wait = app_config.get('BETWEEN_NODES_WAIT', 0)
+                        if wait:
+                            time.sleep(wait)
+
+                # update our in-memory state so the final scale_asg is correct
+                asg_state[asg_name] = (desired_cap, od, om)
+
+            logger.info(f'Processed batch of {len(batch)} nodes for ASG {asg_name}')
+
+        # 3) SCALE BACK ONCE to original desired/max
+        new_d, orig_d, orig_m = asg_state[asg_name]
+        logger.info(f'Scaling ASG {asg_name} back to original desired {orig_d}')
+        scale_asg(asg_name, new_d, orig_d, orig_m)
+
+        # 4) resume AWS policies
+        if not use_asg_termination_policy:
+            modify_aws_autoscaling(asg_name, 'resume')
+
+        # 5) clean up all tags
         delete_asg_tags(asg_name, app_config["ASG_DESIRED_STATE_TAG"])
         delete_asg_tags(asg_name, app_config["ASG_ORIG_CAPACITY_TAG"])
         delete_asg_tags(asg_name, app_config["ASG_ORIG_MAX_CAPACITY_TAG"])
-        logger.info(f'*** Rolling update of asg {asg_name} is complete! ***')
-    logger.info('All asgs processed')
+
+        logger.info(f'*** Completed rolling update for ASG {asg_name} ***')
+
+    logger.info('All ASGs processed')
+
 
 
 def main(args=None):

--- a/eksrollup/config.py
+++ b/eksrollup/config.py
@@ -32,6 +32,7 @@ app_config = {
     'MAX_ALLOWABLE_NODE_AGE': int(os.getenv('MAX_ALLOWABLE_NODE_AGE', 6)),
     'TAINT_NODES': str_to_bool(os.getenv('TAINT_NODES', False)),
     'BATCH_SIZE': int(os.getenv('BATCH_SIZE', 0)),
+    'ROLLOUT_BATCH_SIZE': int(os.getenv('ROLLOUT_BATCH_SIZE', None)),
     'ENFORCED_DRAINING': str_to_bool(os.getenv('ENFORCED_DRAINING', False)),
     'ASG_NAMES': os.getenv('ASG_NAMES', '').split()
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-boto3~=1.26.153
-kubernetes~=25.3.0
-python-dotenv~=0.10.2
-urllib3<1.26
+boto3~=1.38.14
+kubernetes~=32.0.1
+python-dotenv~=1.1.0
+
+setuptools~=80.0.0
+requests~=2.32.3


### PR DESCRIPTION
Added the `ROLLOUT_BATCH_SIZE` setting to the configuration so you can control how many nodes are added to—or removed from—an Auto Scaling Group in each batch. This enables true batch-by-batch rollouts.

Below is the script log from staging-use1 for the reviewer to confirm it’s working as expected. It was run with:

* `RUN_MODE=1`
* `ROLLOUT_BATCH_SIZE=1`
* ASG: `ara-staging-use1-deployments-primary20210430180106810600000020`

<details>
  <summary>Full script log</summary>

```log
Rolling ara-staging-use1-deployments-primary20210430180106810600000020 ...
2025-05-15 09:53:22,766 INFO     Describing autoscaling groups...
2025-05-15 09:53:23,385 INFO     Pausing k8s autoscaler...
2025-05-15 09:53:24,271 INFO     K8s autoscaler modified to replicas: 0
2025-05-15 09:53:24,273 INFO     *** Checking for nodes older than 0 days in autoscaling group ara-staging-use1-deployments-primary20210430180106810600000020 ***
2025-05-15 09:53:24,941 INFO     Instance id i-07aa751dd18934ff4 launch age of '63' day(s) is older than expected '0' day(s)
2025-05-15 09:53:25,287 INFO     Instance id i-0ff60384f072f7166 is older than expected '0' day(s) by 1872 seconds.
2025-05-15 09:53:25,287 INFO     Found 2 outdated instances
2025-05-15 09:53:25,295 INFO     Getting k8s nodes...
2025-05-15 09:53:26,813 INFO     Current total k8s node count is 13 (included: 13, excluded: 0)
2025-05-15 09:53:43,192 INFO     Scaling ASG ara-staging-use1-deployments-primary20210430180106810600000020 up by 1 for batch head-room
2025-05-15 09:53:43,193 INFO     Modifying asg ara-staging-use1-deployments-primary20210430180106810600000020 autoscaling to resume ...
2025-05-15 09:53:43,647 INFO     No previous capacity value tags set on ASG; setting tags.
2025-05-15 09:53:43,648 INFO     Saving tag to asg key: eks-rolling-update:original_capacity, value : 2...
2025-05-15 09:53:43,872 INFO     Saving tag to asg key: eks-rolling-update:desired_capacity, value : 3...
2025-05-15 09:53:44,074 INFO     Saving tag to asg key: eks-rolling-update:original_max_capacity, value : 5...
2025-05-15 09:53:44,259 INFO     Setting asg desired capacity from 2 to 3 and max size to 5...
2025-05-15 09:53:44,487 INFO     Waiting for 90 seconds for ASG to scale before validating cluster health...
2025-05-15 09:55:14,488 INFO     Checking asg ara-staging-use1-deployments-primary20210430180106810600000020 instance count...
2025-05-15 09:55:14,992 INFO     Asg ara-staging-use1-deployments-primary20210430180106810600000020 scaled OK
2025-05-15 09:55:14,993 INFO     Actual instances: 3 Desired instances: 3
2025-05-15 09:55:14,993 INFO     Checking asg ara-staging-use1-deployments-primary20210430180106810600000020 instance health...
2025-05-15 09:55:15,114 INFO     Instance i-06fa244f537e584b5 - Healthy
2025-05-15 09:55:15,114 INFO     Instance i-07aa751dd18934ff4 - Healthy
2025-05-15 09:55:15,114 INFO     Instance i-0ff60384f072f7166 - Healthy
2025-05-15 09:55:15,119 INFO     Getting k8s nodes...
2025-05-15 09:55:16,751 INFO     Current total k8s node count is 14 (included: 14, excluded: 0)
2025-05-15 09:55:16,751 INFO     Describing autoscaling groups...
2025-05-15 09:55:17,071 INFO     Searching for k8s node name by instance id...
2025-05-15 09:55:17,071 INFO     InstanceId i-03d18ba73d9aeca1b is node ip-10-2-81-52.ec2.internal in kubernetes land
2025-05-15 09:55:17,072 INFO     Searching for k8s node name by instance id...
2025-05-15 09:55:17,072 INFO     InstanceId i-0702aa0ae9a71f132 is node ip-10-2-134-15.ec2.internal in kubernetes land
2025-05-15 09:55:17,072 INFO     Searching for k8s node name by instance id...
2025-05-15 09:55:17,072 INFO     InstanceId i-0e874edbbaeeaab11 is node ip-10-2-251-72.ec2.internal in kubernetes land
2025-05-15 09:55:17,072 INFO     Searching for k8s node name by instance id...
2025-05-15 09:55:17,072 INFO     InstanceId i-06fa244f537e584b5 is node ip-10-2-211-65.ec2.internal in kubernetes land
2025-05-15 09:55:17,072 INFO     Searching for k8s node name by instance id...
2025-05-15 09:55:17,072 INFO     InstanceId i-07aa751dd18934ff4 is node ip-10-2-187-18.ec2.internal in kubernetes land
2025-05-15 09:55:17,072 INFO     Searching for k8s node name by instance id...
2025-05-15 09:55:17,072 INFO     InstanceId i-0ff60384f072f7166 is node ip-10-2-72-83.ec2.internal in kubernetes land
2025-05-15 09:55:17,072 INFO     Searching for k8s node name by instance id...
2025-05-15 09:55:17,072 INFO     InstanceId i-0f0c2b72afef7c6ee is node ip-10-2-103-46.ec2.internal in kubernetes land
2025-05-15 09:55:17,072 INFO     Searching for k8s node name by instance id...
2025-05-15 09:55:17,072 INFO     InstanceId i-047e7501539ffc006 is node ip-10-2-80-46.ec2.internal in kubernetes land
2025-05-15 09:55:17,073 INFO     Searching for k8s node name by instance id...
2025-05-15 09:55:17,073 INFO     InstanceId i-0c842647303ee055c is node ip-10-2-163-97.ec2.internal in kubernetes land
2025-05-15 09:55:17,073 INFO     Searching for k8s node name by instance id...
2025-05-15 09:55:17,073 INFO     InstanceId i-0fab131f614687b21 is node ip-10-2-192-197.ec2.internal in kubernetes land
2025-05-15 09:55:17,073 INFO     Searching for k8s node name by instance id...
2025-05-15 09:55:17,073 INFO     InstanceId i-06b0a40ac35468396 is node ip-10-2-219-120.ec2.internal in kubernetes land
2025-05-15 09:55:17,073 INFO     Searching for k8s node name by instance id...
2025-05-15 09:55:17,073 INFO     InstanceId i-0d6189a5b2b23e821 is node ip-10-2-131-39.ec2.internal in kubernetes land
2025-05-15 09:55:17,073 INFO     Searching for k8s node name by instance id...
2025-05-15 09:55:17,073 INFO     InstanceId i-093ac649b0d2b9d39 is node ip-10-2-86-11.ec2.internal in kubernetes land
2025-05-15 09:55:17,073 INFO     Searching for k8s node name by instance id...
2025-05-15 09:55:17,073 INFO     InstanceId i-0b34bcb80caff790d is node ip-10-2-104-101.ec2.internal in kubernetes land
2025-05-15 09:55:17,073 INFO     Current asg instance count in cluster is: 14. K8s node count should match this number
2025-05-15 09:55:17,073 INFO     Checking k8s expected nodes are online after asg scaled up...
2025-05-15 09:55:17,076 INFO     Getting k8s nodes...
2025-05-15 09:55:18,616 INFO     Current total k8s node count is 14 (included: 14, excluded: 0)
2025-05-15 09:55:18,617 INFO     Current k8s node count is 14
2025-05-15 09:55:18,617 INFO     Reached desired k8s node count of 14
2025-05-15 09:55:18,617 INFO     Checking k8s nodes health status...
2025-05-15 09:55:18,620 INFO     Getting k8s nodes...
2025-05-15 09:55:20,196 INFO     Current total k8s node count is 14 (included: 14, excluded: 0)
2025-05-15 09:55:20,197 INFO     Node ip-10-2-103-46.ec2.internal: Ready
2025-05-15 09:55:20,197 INFO     Node ip-10-2-104-101.ec2.internal: Ready
2025-05-15 09:55:20,197 INFO     Node ip-10-2-131-39.ec2.internal: Ready
2025-05-15 09:55:20,197 INFO     Node ip-10-2-134-15.ec2.internal: Ready
2025-05-15 09:55:20,197 INFO     Node ip-10-2-163-97.ec2.internal: Ready
2025-05-15 09:55:20,197 INFO     Node ip-10-2-187-18.ec2.internal: Ready
2025-05-15 09:55:20,197 INFO     Node ip-10-2-192-197.ec2.internal: Ready
2025-05-15 09:55:20,197 INFO     Node ip-10-2-211-65.ec2.internal: Ready
2025-05-15 09:55:20,197 INFO     Node ip-10-2-219-120.ec2.internal: Ready
2025-05-15 09:55:20,197 INFO     Node ip-10-2-251-72.ec2.internal: Ready
2025-05-15 09:55:20,197 INFO     Node ip-10-2-72-83.ec2.internal: Ready
2025-05-15 09:55:20,197 INFO     Node ip-10-2-80-46.ec2.internal: Ready
2025-05-15 09:55:20,197 INFO     Node ip-10-2-81-52.ec2.internal: Ready
2025-05-15 09:55:20,197 INFO     Node ip-10-2-86-11.ec2.internal: Ready
2025-05-15 09:55:20,197 INFO     All k8s nodes are healthy
2025-05-15 09:55:20,197 INFO     Cluster validation passed. Proceeding with node draining and termination...
2025-05-15 09:55:20,197 INFO     Proceeding with node draining and termination...
2025-05-15 09:55:20,197 INFO     Saving tag to asg key: eks-rolling-update:desired_capacity, value : 3...
2025-05-15 09:55:20,413 INFO     Saving tag to asg key: eks-rolling-update:original_capacity, value : 2...
2025-05-15 09:55:20,637 INFO     Saving tag to asg key: eks-rolling-update:original_max_capacity, value : 5...
2025-05-15 09:55:25,970 INFO     Modifying asg ara-staging-use1-deployments-primary20210430180106810600000020 autoscaling to suspend ...
2025-05-15 09:55:26,132 INFO     Searching for k8s node name by instance id...
2025-05-15 09:55:26,132 INFO     InstanceId i-07aa751dd18934ff4 is node ip-10-2-187-18.ec2.internal in kubernetes land
2025-05-15 09:55:26,140 INFO     Cordoning k8s node ip-10-2-187-18.ec2.internal...
2025-05-15 09:55:27,097 INFO     Node cordoned
2025-05-15 09:55:27,100 INFO     Searching for k8s node name by instance id...
2025-05-15 09:55:27,100 INFO     InstanceId i-07aa751dd18934ff4 is node ip-10-2-187-18.ec2.internal in kubernetes land
2025-05-15 09:55:27,100 INFO     Draining worker node with kubectl drain ip-10-2-187-18.ec2.internal --ignore-daemonsets --delete-emptydir-data --grace-period=0 --force=true...
node/ip-10-2-187-18.ec2.internal already cordoned
Warning: ignoring DaemonSet-managed Pods: calico-system/calico-node-29tjd, calico-system/csi-node-driver-v6fj2, ingress/ingress-nginx-controller-pv5bc, kube-system/aws-node-w7v2n, kube-system/kube-proxy-kqlc6, logging/filebeat-2p5fc, longhorn-system/engine-image-ei-2df3ee3d-fs8bm, longhorn-system/longhorn-csi-plugin-xzb2m, longhorn-system/longhorn-manager-58z2p, prometheus-stack/prometheus-stack-prometheus-node-exporter-24s9m, velero/node-agent-79kj2
evicting pod longhorn-system/csi-provisioner-6674ff8867-msn68
evicting pod longhorn-system/longhorn-ui-595fcdb7b8-8dz4k
evicting pod cert-manager/cert-manager-cainjector-6c58576757-grkhr
evicting pod snapshot-controller/snapshot-controller-66c956758c-5l257
evicting pod longhorn-system/instance-manager-9524596d089f29c0594878dc3741fc9a
evicting pod plastic-muscle/tyk-dashboard-9f7c5c7d7-jbr9r
evicting pod plastic-muscle/tyk-mdcb-775b746bc-67p2h
evicting pod initial-paintwork/tyk-enterprise-portal-5774cbd7fd-w9cx4
evicting pod shocked-moth/tyk-gateway-6bdcf58848-qbpcr
evicting pod shocked-moth/tyk-mdcb-56895c9bb6-wfktc
evicting pod plastic-muscle/tyk-gateway-844989b787-6b9rc
evicting pod shocked-moth/tyk-dashboard-7dc76c65bd-q872s
evicting pod longhorn-system/csi-resizer-74d68487d8-z82bm
pod/instance-manager-9524596d089f29c0594878dc3741fc9a evicted
pod/longhorn-ui-595fcdb7b8-8dz4k evicted
pod/tyk-dashboard-9f7c5c7d7-jbr9r evicted
pod/snapshot-controller-66c956758c-5l257 evicted
pod/csi-provisioner-6674ff8867-msn68 evicted
pod/cert-manager-cainjector-6c58576757-grkhr evicted
pod/tyk-gateway-6bdcf58848-qbpcr evicted
pod/tyk-mdcb-56895c9bb6-wfktc evicted
pod/tyk-dashboard-7dc76c65bd-q872s evicted
pod/tyk-mdcb-775b746bc-67p2h evicted
pod/tyk-gateway-844989b787-6b9rc evicted
pod/tyk-enterprise-portal-5774cbd7fd-w9cx4 evicted
pod/csi-resizer-74d68487d8-z82bm evicted
node/ip-10-2-187-18.ec2.internal drained
2025-05-15 09:55:33,254 INFO     Deleting k8s node ip-10-2-187-18.ec2.internal...
2025-05-15 09:55:34,135 INFO     Node deleted
2025-05-15 09:55:34,138 INFO     Saving tag to asg key: eks-rolling-update:desired_capacity, value : 3...
2025-05-15 09:55:34,561 INFO     Terminating ec2 instance in ASG i-07aa751dd18934ff4...
2025-05-15 09:55:34,757 INFO     Termination signal for instance is successfully sent.
2025-05-15 09:55:34,757 INFO     Checking instance i-07aa751dd18934ff4 is terminated...
2025-05-15 09:55:35,339 INFO     Instance i-07aa751dd18934ff4 is running, checking again...
2025-05-15 09:55:55,344 INFO     Checking instance i-07aa751dd18934ff4 is terminated...
2025-05-15 09:55:55,817 INFO     Instance i-07aa751dd18934ff4 is shutting-down, checking again...
2025-05-15 09:56:15,821 INFO     Checking instance i-07aa751dd18934ff4 is terminated...
2025-05-15 09:56:16,068 INFO     Instance i-07aa751dd18934ff4 is shutting-down, checking again...
2025-05-15 09:56:36,070 INFO     Checking instance i-07aa751dd18934ff4 is terminated...
2025-05-15 09:56:36,300 INFO     Instance i-07aa751dd18934ff4 is shutting-down, checking again...
2025-05-15 09:56:56,303 INFO     Checking instance i-07aa751dd18934ff4 is terminated...
2025-05-15 09:56:56,542 INFO     Instance i-07aa751dd18934ff4 is shutting-down, checking again...
2025-05-15 09:57:16,547 INFO     Checking instance i-07aa751dd18934ff4 is terminated...
2025-05-15 09:57:16,953 INFO     Instance i-07aa751dd18934ff4 is shutting-down, checking again...
2025-05-15 09:57:36,958 INFO     Checking instance i-07aa751dd18934ff4 is terminated...
2025-05-15 09:57:37,195 INFO     Instance i-07aa751dd18934ff4 is shutting-down, checking again...
2025-05-15 09:57:57,199 INFO     Checking instance i-07aa751dd18934ff4 is terminated...
2025-05-15 09:57:57,368 INFO     Instance i-07aa751dd18934ff4 is shutting-down, checking again...
2025-05-15 09:58:17,372 INFO     Checking instance i-07aa751dd18934ff4 is terminated...
2025-05-15 09:58:17,536 INFO     Instance i-07aa751dd18934ff4 terminated!
2025-05-15 09:59:17,541 INFO     Processed batch of 1 nodes for ASG ara-staging-use1-deployments-primary20210430180106810600000020
2025-05-15 09:59:17,541 INFO     Searching for k8s node name by instance id...
2025-05-15 09:59:17,541 INFO     InstanceId i-0ff60384f072f7166 is node ip-10-2-72-83.ec2.internal in kubernetes land
2025-05-15 09:59:17,560 INFO     Cordoning k8s node ip-10-2-72-83.ec2.internal...
2025-05-15 09:59:18,618 INFO     Node cordoned
2025-05-15 09:59:18,622 INFO     Searching for k8s node name by instance id...
2025-05-15 09:59:18,622 INFO     InstanceId i-0ff60384f072f7166 is node ip-10-2-72-83.ec2.internal in kubernetes land
2025-05-15 09:59:18,622 INFO     Draining worker node with kubectl drain ip-10-2-72-83.ec2.internal --ignore-daemonsets --delete-emptydir-data --grace-period=0 --force=true...
node/ip-10-2-72-83.ec2.internal already cordoned
Warning: ignoring DaemonSet-managed Pods: calico-system/calico-node-hc4np, calico-system/csi-node-driver-97555, ingress/ingress-nginx-controller-vxlpr, kube-system/aws-node-ptzpw, kube-system/kube-proxy-8nlrp, logging/filebeat-x88lx, longhorn-system/engine-image-ei-2df3ee3d-hbbwp, longhorn-system/longhorn-csi-plugin-kh6dh, longhorn-system/longhorn-manager-wngs6, prometheus-stack/prometheus-stack-prometheus-node-exporter-p48db, velero/node-agent-zdt9g
evicting pod shocked-moth/tyk-mdcb-56895c9bb6-lbvd8
evicting pod longhorn-system/instance-manager-026c6e19e9249ed796a79ef0051bb1e6
evicting pod initial-paintwork/tyk-enterprise-portal-5774cbd7fd-krxl5
evicting pod plastic-muscle/tyk-mdcb-775b746bc-xx27w
evicting pod shocked-moth/tyk-dashboard-7dc76c65bd-7cj44
evicting pod plastic-muscle/tyk-dashboard-9f7c5c7d7-qbl55
evicting pod plastic-muscle/tyk-gateway-844989b787-t9v2d
evicting pod shocked-moth/tyk-gateway-6bdcf58848-6559z
pod/tyk-gateway-6bdcf58848-6559z evicted
pod/tyk-mdcb-56895c9bb6-lbvd8 evicted
pod/tyk-dashboard-7dc76c65bd-7cj44 evicted
pod/tyk-enterprise-portal-5774cbd7fd-krxl5 evicted
pod/instance-manager-026c6e19e9249ed796a79ef0051bb1e6 evicted
pod/tyk-mdcb-775b746bc-xx27w evicted
pod/tyk-dashboard-9f7c5c7d7-qbl55 evicted
pod/tyk-gateway-844989b787-t9v2d evicted
node/ip-10-2-72-83.ec2.internal drained
2025-05-15 09:59:23,861 INFO     Deleting k8s node ip-10-2-72-83.ec2.internal...
2025-05-15 09:59:24,640 INFO     Node deleted
2025-05-15 09:59:24,643 INFO     Saving tag to asg key: eks-rolling-update:desired_capacity, value : 3...
2025-05-15 09:59:25,087 INFO     Terminating ec2 instance in ASG i-0ff60384f072f7166...
2025-05-15 09:59:25,358 INFO     Termination signal for instance is successfully sent.
2025-05-15 09:59:25,358 INFO     Checking instance i-0ff60384f072f7166 is terminated...
2025-05-15 09:59:25,892 INFO     Instance i-0ff60384f072f7166 is running, checking again...
2025-05-15 09:59:45,893 INFO     Checking instance i-0ff60384f072f7166 is terminated...
2025-05-15 09:59:46,129 INFO     Instance i-0ff60384f072f7166 is shutting-down, checking again...
2025-05-15 10:00:06,114 INFO     Checking instance i-0ff60384f072f7166 is terminated...
2025-05-15 10:00:06,344 INFO     Instance i-0ff60384f072f7166 is shutting-down, checking again...
2025-05-15 10:00:26,339 INFO     Checking instance i-0ff60384f072f7166 is terminated...
2025-05-15 10:00:26,619 INFO     Instance i-0ff60384f072f7166 is shutting-down, checking again...
2025-05-15 10:00:46,618 INFO     Checking instance i-0ff60384f072f7166 is terminated...
2025-05-15 10:00:46,773 INFO     Instance i-0ff60384f072f7166 is shutting-down, checking again...
2025-05-15 10:01:06,773 INFO     Checking instance i-0ff60384f072f7166 is terminated...
2025-05-15 10:01:06,970 INFO     Instance i-0ff60384f072f7166 is shutting-down, checking again...
2025-05-15 10:01:26,973 INFO     Checking instance i-0ff60384f072f7166 is terminated...
2025-05-15 10:01:27,131 INFO     Instance i-0ff60384f072f7166 is shutting-down, checking again...
2025-05-15 10:01:47,135 INFO     Checking instance i-0ff60384f072f7166 is terminated...
2025-05-15 10:01:47,307 INFO     Instance i-0ff60384f072f7166 terminated!
2025-05-15 10:02:47,308 INFO     Processed batch of 1 nodes for ASG ara-staging-use1-deployments-primary20210430180106810600000020
2025-05-15 10:02:47,308 INFO     Scaling ASG ara-staging-use1-deployments-primary20210430180106810600000020 back to original desired 2
2025-05-15 10:02:47,309 INFO     Setting asg desired capacity from 3 to 2 and max size to 5...
2025-05-15 10:02:47,827 INFO     Modifying asg ara-staging-use1-deployments-primary20210430180106810600000020 autoscaling to resume ...
2025-05-15 10:02:48,048 INFO     Deleting tag from asg key: eks-rolling-update:desired_capacity...
2025-05-15 10:02:48,273 INFO     Deleting tag from asg key: eks-rolling-update:original_capacity...
2025-05-15 10:02:48,613 INFO     Deleting tag from asg key: eks-rolling-update:original_max_capacity...
2025-05-15 10:02:48,780 INFO     *** Completed rolling update for ASG ara-staging-use1-deployments-primary20210430180106810600000020 ***
2025-05-15 10:02:48,780 INFO     All ASGs processed
2025-05-15 10:02:48,793 INFO     Resuming k8s autoscaler...
2025-05-15 10:02:49,736 INFO     K8s autoscaler modified to replicas: 2
2025-05-15 10:02:49,739 INFO     *** Rolling update of all asg is complete! ***
```
</details> 